### PR TITLE
Refresh public project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,55 @@
-<p align="center">
-  <a href="" rel="noopener">
- <img width=300px src="https://cdn3.iconfinder.com/data/icons/monosign/142/invoice-512.png" alt="Invoice-logo"></a>
-</p>
+﻿# Bill Print Format
 
-# Bill-Print-Format
-It is invoice format to print bills.It consists of SGST & CGST calculations.
+A small operational utility for formatting and printing bills. It includes an HTML bill template, source code, requirements, and a packaged Windows output folder.
 
-# Speciality
-Desktop Application compatible with WIndows 7,Windows 10,Linux,Mac.
-Online Billing & Printing facility available at site.
-For Windows XP can use Window.html offline in browser to generate and print bill.
+## Repository Status
 
-<p align="center">
-<img src ="./Invoice.jpg" width = 500px>
-</p>
-# File Structure
-billprint-win32-x64 (Desktop Software Folder) -> billprint.exe
+- Current role: Desktop-oriented bill printing utility with HTML template and packaged Windows artifact
+- Documentation status: refreshed for public review
+- Primary audience: engineers, product reviewers, and collaborators evaluating the project context
 
-# Source File
-Run Requirements.txt
-Run npm start in Source code folder
+## What This Project Does
 
-Online Billing and Printing
-https://bill-print.herokuapp.com/
+- HTML bill print template
+- Source code folder for maintainable edits
+- Requirements file for runtime dependencies
+- Packaged Windows output artifact
+
+## Technology Stack
+
+- HTML template
+- Python or desktop packaging workflow implied by requirements and win32 output
+- Windows packaged artifact
+- Local file-based operation
+
+## Repository Map
+
+- BillPrint.html contains the printable format
+- Source Code/ contains source implementation
+- Requirements.txt lists dependencies
+- billprint-win32-x64/ contains packaged output
+
+## Getting Started
+
+- Review Requirements.txt
+- Install dependencies in a local environment if running from source
+- Open or run the source workflow locally
+- Use the packaged Windows output only after confirming it matches the current source
+
+## Documentation
+
+- docs/overview.md - product context, users, scope, and outcomes
+- docs/architecture.md - components, data flow, and sequence diagrams
+- docs/operations.md - setup, validation, maintenance, and known risks
+
+## Known Limitations
+
+- Packaged output can drift from source unless releases are documented
+- Printer margins and paper sizes vary by environment
+- Billing rules and tax behavior must be configured for the real business context
+
+## Notes For Future Maintainers
+
+This repository documents the original project intent and the implementation shape visible in the codebase. Before production use, review dependencies, environment configuration, data handling, and deployment assumptions against current standards.
+
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,44 @@
+﻿# Architecture
+
+The project centers on a printable HTML format and local source workflow, with a packaged Windows artifact for easier operation.
+
+## Component View
+
+```mermaid
+flowchart LR
+  Actor["Operator"] --> Entry["Desktop or HTML interface"]
+  Entry --> Service["Bill formatting logic"]
+  Service --> Data["Local bill fields"]
+  Service --> External["Printer and Windows runtime"]
+```
+
+## Key Components
+
+- Printable HTML template
+- Source code folder
+- Dependency requirements
+- Packaged Windows output
+
+## Main Workflow
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Client
+  participant App
+  participant Store
+  User->>Client: Prepares bill details
+  Client->>App: Generates print format
+  App->>Store: Validate and persist state
+  Store-->>App: Local bill layout prepared
+  App-->>Client: Prints or previews bill
+  Client-->>User: Present updated result
+```
+
+## Design Considerations
+
+- Prioritize predictable layout
+- Keep business-specific fields configurable
+- Treat packaged output as a release artifact
+
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,30 @@
+﻿# Operations
+
+These notes capture the practical work needed to run, maintain, or modernize the repository from its current state.
+
+## Local Operation
+
+- Review Requirements.txt
+- Install dependencies in a local environment if running from source
+- Open or run the source workflow locally
+- Use the packaged Windows output only after confirming it matches the current source
+
+## Validation
+
+- Open the bill template and verify print layout
+- Run source workflow from a clean environment
+- Test against target printer and paper size
+
+## Maintenance Notes
+
+- Document release steps for packaged output
+- Keep requirements current
+- Separate sample data from business data
+
+## Operational Risks
+
+- Packaged output can drift from source unless releases are documented
+- Printer margins and paper sizes vary by environment
+- Billing rules and tax behavior must be configured for the real business context
+
+

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,27 @@
+﻿# Overview
+
+The project is a practical operations tool: produce a predictable bill print format for a local workflow where layout reliability matters more than system complexity.
+
+## Problem Space
+
+Small business tools often need to solve one narrow workflow well. Printing a clean bill is valuable when it saves manual formatting and reduces mistakes at the counter.
+
+## Primary Users
+
+- Small business operator printing bills
+- Developer maintaining a local desktop utility
+- Reviewer evaluating pragmatic workflow software
+
+## Scope
+
+- Bill layout and print workflow
+- Local desktop use
+- Source and packaged artifact organization
+
+## Outcomes To Evaluate
+
+- Use case is understandable
+- Printer and packaging assumptions are explicit
+- Maintenance path is clear
+
+


### PR DESCRIPTION
## Summary
- Refresh the public README with a neutral project overview, stack, setup notes, and limitations.
- Add standard documentation under docs/ where useful: overview, architecture, product, and operations.
- Keep the content professional and repository-focused without strategy-specific document names.

## Validation
- Documentation-only change.
- Verified README docs links locally across the refresh batch.